### PR TITLE
B-20438 and B-20440: updated to correct version as referenced elsewhere and added publicPath config setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@trussworks/react-file-viewer",
-  "version": "1.2.1",
+  "name": "@transcom/react-file-viewer",
+  "version": "1.2.4",
   "description": "Extendable file viewer for web",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ const config = {
     filename: 'index.js',
     library: ['FileViewer'],
     libraryTarget: 'umd',
+    publicPath: '/',
   },
   resolve: {
     modules: [path.resolve(__dirname, './src'), 'node_modules'],


### PR DESCRIPTION
This is to fix an error present on a repo that is importing this component.
Error: Automatic publicPath is not supported in this browser

The hope is that by adding in the publicPath variable to the production configs for webpack on the @transcom/react-file-viewer repo, it will no longer be using automatic path resolution for the publicPath config setting.

![image](https://github.com/user-attachments/assets/0e13870c-36b2-4a94-9ef4-2dc16b1f0893)
